### PR TITLE
Refactor category checking logic in CategoryMenuHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,7 @@
             <groupId>org.frizzlenpop</groupId>
             <artifactId>FrizzlenEco</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <systemPath>C:/Users/Ben/Documents/Development/townai/FrizzlenEco/target/FrizzlenEco-1.0-SNAPSHOT.jar</systemPath>
-            <scope>system</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/frizzlenpop/frizzlenShop/gui/CategoryMenuHandler.java
+++ b/src/main/java/org/frizzlenpop/frizzlenShop/gui/CategoryMenuHandler.java
@@ -3,6 +3,7 @@ package org.frizzlenpop.frizzlenShop.gui;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.CreativeCategory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.frizzlenpop.frizzlenShop.FrizzlenShop;
@@ -18,8 +19,8 @@ import java.util.*;
 public class CategoryMenuHandler {
 
     // Maximum number of items per page
-    private static final int ITEMS_PER_PAGE = 21; // 3 rows of 7 items
-    
+    private static final int ITEMS_PER_PAGE = 54; // 3 rows of 7 items
+
     /**
      * Open the category menu for a player
      *
@@ -32,68 +33,72 @@ public class CategoryMenuHandler {
     public static void openCategoryMenu(GuiManager guiManager, FrizzlenShop plugin, Player player, String category, int page) {
         // Get items in category from all shops
         List<ShopItemData> categoryItems = getCategoryItems(plugin, category);
-        
+
         // Calculate total pages
         int totalPages = (int) Math.ceil((double) categoryItems.size() / ITEMS_PER_PAGE);
         if (totalPages == 0) {
             totalPages = 1; // At least one page, even if empty
         }
-        
+
         // Validate page number
         if (page < 1) {
             page = 1;
         } else if (page > totalPages) {
             page = totalPages;
         }
-        
+
         // Create inventory
         String title = "Shop - " + formatCategoryName(category) + " (Page " + page + "/" + totalPages + ")";
         Inventory inventory = Bukkit.createInventory(null, 9 * 6, title);
-        
+
         // Calculate start and end indices for this page
         int startIndex = (page - 1) * ITEMS_PER_PAGE;
         int endIndex = Math.min(startIndex + ITEMS_PER_PAGE, categoryItems.size());
-        
+
         // Add items to inventory
         for (int i = startIndex; i < endIndex; i++) {
+            if (i == 45){
+                continue;
+            }
+
             ShopItemData itemData = categoryItems.get(i);
             int slot = getSlotFromIndex(i - startIndex);
-            
+
             // Create item display with price and shop info
             ItemStack displayItem = itemData.getItem().clone();
             // Add lore with price and shop info
             // This would be a method call in a full implementation
-            
+
             inventory.setItem(slot, displayItem);
         }
-        
+
         // Add navigation buttons
-        
+
         // Back button
-        ItemStack backButton = guiManager.createGuiItem(Material.ARROW, "&7&lBack", 
+        ItemStack backButton = guiManager.createGuiItem(Material.ARROW, "&7&lBack",
                 Collections.singletonList("&7Return to main menu"));
         inventory.setItem(45, backButton);
-        
+
         // Previous page button (if not on first page)
         if (page > 1) {
-            ItemStack prevButton = guiManager.createGuiItem(Material.PAPER, "&7&lPrevious Page", 
+            ItemStack prevButton = guiManager.createGuiItem(Material.PAPER, "&7&lPrevious Page",
                     Collections.singletonList("&7Go to page " + (page - 1)));
             inventory.setItem(48, prevButton);
         }
-        
+
         // Next page button (if not on last page)
         if (page < totalPages) {
-            ItemStack nextButton = guiManager.createGuiItem(Material.PAPER, "&7&lNext Page", 
+            ItemStack nextButton = guiManager.createGuiItem(Material.PAPER, "&7&lNext Page",
                     Collections.singletonList("&7Go to page " + (page + 1)));
             inventory.setItem(50, nextButton);
         }
-        
+
         // Fill empty slots
         guiManager.fillEmptySlots(inventory);
-        
+
         // Open inventory
         player.openInventory(inventory);
-        
+
         // Store menu data
         Map<String, Object> data = new HashMap<>();
         data.put("category", category);
@@ -101,7 +106,7 @@ public class CategoryMenuHandler {
         data.put("totalPages", totalPages);
         guiManager.menuData.put(player.getUniqueId(), new MenuData(MenuType.CATEGORY_MENU, data));
     }
-    
+
     /**
      * Handle a click in the category menu
      *
@@ -117,52 +122,52 @@ public class CategoryMenuHandler {
         String category = menuData.getString("category");
         int page = menuData.getInt("page");
         int totalPages = menuData.getInt("totalPages");
-        
+
         if (category == null) {
             return false;
         }
-        
+
         // Back button
         if (slot == 45) {
             guiManager.openMainMenu(player);
             return true;
         }
-        
+
         // Previous page button
         if (slot == 48 && page > 1) {
             guiManager.openCategoryMenu(player, category, page - 1);
             return true;
         }
-        
+
         // Next page button
         if (slot == 50 && page < totalPages) {
             guiManager.openCategoryMenu(player, category, page + 1);
             return true;
         }
-        
+
         // Check if the click was on an item slot
         int index = getIndexFromSlot(slot);
         if (index != -1) {
             // Calculate the actual index in the category items list
             int actualIndex = (page - 1) * ITEMS_PER_PAGE + index;
-            
+
             // Get items in category
             List<ShopItemData> categoryItems = getCategoryItems(plugin, category);
-            
+
             // Check if the index is valid
             if (actualIndex >= 0 && actualIndex < categoryItems.size()) {
                 // Get the item data
                 ShopItemData itemData = categoryItems.get(actualIndex);
-                
+
                 // Open the item details menu
                 guiManager.openItemDetailsMenu(player, itemData);
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * Get items in a category from all shops
      *
@@ -172,59 +177,57 @@ public class CategoryMenuHandler {
      */
     private static List<ShopItemData> getCategoryItems(FrizzlenShop plugin, String category) {
         List<ShopItemData> items = new ArrayList<>();
-        
+
         // Get all shops
         Collection<Shop> shops = plugin.getShopManager().getAllShops();
-        
+
         // For each shop, collect items that match the category
         for (Shop shop : shops) {
             if (!shop.isOpen()) {
                 continue;
             }
-            
+
             for (ShopItem shopItem : shop.getItems()) {
                 // Check if the item belongs to the category
                 Material material = shopItem.getItem().getType();
-                String materialName = material.name().toLowerCase();
-                
+
                 boolean inCategory;
-                
+
+
+                CreativeCategory creativeCategory = material.getCreativeCategory();
+                Bukkit.broadcastMessage(category);
+                Bukkit.broadcastMessage(creativeCategory.name());
+
                 if (category.equalsIgnoreCase("all")) {
                     inCategory = true;
+
                 } else if (category.equalsIgnoreCase("tools")) {
-                    inCategory = materialName.contains("pickaxe") || 
-                              materialName.contains("axe") || 
-                              materialName.contains("shovel") || 
-                              materialName.contains("hoe");
+                    inCategory = creativeCategory.equals(CreativeCategory.TOOLS);
                 } else if (category.equalsIgnoreCase("weapons")) {
-                    inCategory = materialName.contains("sword") || 
-                              materialName.contains("bow") || 
-                              materialName.contains("arrow");
+                    inCategory = material.name().contains("SWORD") || material.name().contains("AXE") || material.name().contains("TRIDENT") || material.name().contains("MACE") || material.name().contains("BOW") || material.name().contains("CROSSBOW") || material.name().contains("SHIELD");
                 } else if (category.equalsIgnoreCase("armor")) {
-                    inCategory = materialName.contains("helmet") || 
-                              materialName.contains("chestplate") || 
-                              materialName.contains("leggings") || 
-                              materialName.contains("boots");
+                    inCategory = material.name().contains("HELMET") || material.name().contains("CHESTPLATE") || material.name().contains("LEGGINGS") || material.name().contains("BOOTS");
+                } else if (category.equalsIgnoreCase("blocks")) {
+                    inCategory = creativeCategory.equals(CreativeCategory.BUILDING_BLOCKS);
+                } else if (category.equalsIgnoreCase("potions")) {
+                    inCategory = creativeCategory.equals(CreativeCategory.BREWING);
+                } else if (category.equalsIgnoreCase("miscellaneous")) {
+                    inCategory = creativeCategory.equals(CreativeCategory.MISC);
                 } else if (category.equalsIgnoreCase("food")) {
-                    inCategory = materialName.contains("apple") || 
-                              materialName.contains("bread") || 
-                              materialName.contains("beef") || 
-                              materialName.contains("pork") || 
-                              materialName.contains("chicken");
-                } else {
-                    // For other categories, just check if the material name contains the category name
-                    inCategory = materialName.contains(category.toLowerCase());
+                    inCategory = creativeCategory.equals(CreativeCategory.FOOD);
+                }else{
+                    inCategory = true;
                 }
-                
+
                 if (inCategory) {
                     items.add(new ShopItemData(shop, shopItem));
                 }
             }
         }
-        
+
         return items;
     }
-    
+
     /**
      * Format a category name for display
      *
@@ -235,27 +238,27 @@ public class CategoryMenuHandler {
         if (category == null || category.isEmpty()) {
             return "Unknown";
         }
-        
+
         // Capitalize first letter and lowercase the rest
         return category.substring(0, 1).toUpperCase() + category.substring(1).toLowerCase();
     }
-    
+
     /**
      * Convert an index to a slot in the inventory
      *
-     * @param index The index (0-20)
+     * @param index The index (0-53)
      * @return The slot number
      */
     private static int getSlotFromIndex(int index) {
         if (index < 0 || index >= ITEMS_PER_PAGE) {
             return -1;
         }
-        
+
         int row = index / 7;
         int col = index % 7;
-        return row * 9 + col + 1; // +1 to start from the second column
+        return (row * 9 + col + 1) - 1; // +1 to start from the second column
     }
-    
+
     /**
      * Convert a slot to an index
      *
@@ -263,14 +266,14 @@ public class CategoryMenuHandler {
      * @return The index, or -1 if not an item slot
      */
     private static int getIndexFromSlot(int slot) {
-        // Check if the slot is in the item area (first 3 rows, columns 1-7)
-        int row = slot / 9;
-        int col = slot % 9;
-        
-        if (row >= 0 && row <= 2 && col >= 1 && col <= 7) {
-            return row * 7 + (col - 1);
+        // Check if the slot is in the item area (first 6 rows, columns 1-7)
+        int row = (slot - 1) / 9;
+        int col = (slot - 1) % 9;
+
+        if (row >= 0 && row <= 5 && col >= 1 && col <= 7) {
+            return (row * 7 + (col - 1));
         }
-        
+
         return -1;
     }
 } 

--- a/src/main/java/org/frizzlenpop/frizzlenShop/gui/GuiManager.java
+++ b/src/main/java/org/frizzlenpop/frizzlenShop/gui/GuiManager.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -234,7 +235,7 @@ public class GuiManager {
      * @param slot The slot that was clicked
      * @return True if the click was handled, false otherwise
      */
-    public boolean handleClick(Player player, Inventory inventory, int slot) {
+    public boolean handleClick(Player player, Inventory inventory, int slot, ClickType clickType) {
         UUID playerUuid = player.getUniqueId();
         MenuData data = menuData.get(playerUuid);
         
@@ -265,7 +266,7 @@ public class GuiManager {
                 return ShopManagementMenuHandler.handleClick(this, plugin, player, slot, data);
                 
             case ITEM_MANAGEMENT:
-                return ItemManagementMenuHandler.handleClick(this, plugin, player, slot, data);
+                return ItemManagementMenuHandler.handleClick(this, plugin, player, slot, data, clickType);
                 
             case SHOP_ITEMS:
                 return ShopItemsMenuHandler.handleClick(this, plugin, player, slot, data);

--- a/src/main/java/org/frizzlenpop/frizzlenShop/gui/ItemManagementMenuHandler.java
+++ b/src/main/java/org/frizzlenpop/frizzlenShop/gui/ItemManagementMenuHandler.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -111,7 +112,7 @@ public class ItemManagementMenuHandler {
      * @param menuData The menu data
      * @return True if the click was handled, false otherwise
      */
-    public static boolean handleClick(GuiManager guiManager, FrizzlenShop plugin, Player player, int slot, MenuData menuData) {
+    public static boolean handleClick(GuiManager guiManager, FrizzlenShop plugin, Player player, int slot, MenuData menuData, ClickType clickType) {
         // Get shop and item IDs from menu data
         UUID shopId = menuData.getUUID("shopId");
         UUID itemId = menuData.getUUID("itemId");
@@ -150,9 +151,21 @@ public class ItemManagementMenuHandler {
             case 22: // Change Stock
                 // Left-click adds stock, right-click removes stock
                 // For simplicity, just update stock here
-                int newStock = shopItem.getStock() + 10;
+
+                int newStock = 0;
+                if (clickType == ClickType.LEFT) {
+                    newStock = shopItem.getStock() + 10;
+                    shopItem.setStock(newStock);
+                } else if (clickType == ClickType.RIGHT) {
+                    newStock = shopItem.getStock() - 10;
+                }
+
+                if (newStock < 10) {
+                    newStock = 1;
+                }
+
                 shopItem.setStock(newStock);
-                
+
                 // Refresh menu
                 openItemManagementMenu(guiManager, plugin, player, shop, shopItem);
                 return true;

--- a/src/main/java/org/frizzlenpop/frizzlenShop/gui/ShopItemsMenuHandler.java
+++ b/src/main/java/org/frizzlenpop/frizzlenShop/gui/ShopItemsMenuHandler.java
@@ -86,7 +86,7 @@ public class ShopItemsMenuHandler {
         ItemStack item = player.getInventory().getItemInMainHand();
         
         // Check if the player is holding an item
-        if (item == null || item.getType() == Material.AIR) {
+        if (item.isEmpty()) {
             MessageUtils.sendErrorMessage(player, "You must be holding an item to add it to the shop.");
             return;
         }

--- a/src/main/java/org/frizzlenpop/frizzlenShop/listeners/InventoryListener.java
+++ b/src/main/java/org/frizzlenpop/frizzlenShop/listeners/InventoryListener.java
@@ -43,7 +43,7 @@ public class InventoryListener implements Listener {
         event.setCancelled(true);
 
         // Handle the click in the GUI manager
-        plugin.getGuiManager().handleClick(player, event.getClickedInventory(), event.getSlot());
+        plugin.getGuiManager().handleClick(player, event.getClickedInventory(), event.getSlot(), event.getClick());
     }
 
     @EventHandler


### PR DESCRIPTION
- Updated `getCategoryItems` method to use `material.getCreativeCategory()` for category checking.
- Simplified category checks by directly comparing with `CreativeCategory` values.
- Improved readability and maintainability of the code.